### PR TITLE
Add status-dash skill with version check and project dashboard

### DIFF
--- a/dist/shaktra/.claude-plugin/plugin.json
+++ b/dist/shaktra/.claude-plugin/plugin.json
@@ -2,6 +2,7 @@
   "name": "shaktra",
   "version": "0.1.0",
   "description": "Opinionated software development framework with TDD, quality gates, and multi-agent orchestration",
+  "repository": "https://github.com/im-shashanks/claude-plugins",
   "author": {
     "name": "Shashank"
   },

--- a/dist/shaktra/scripts/check_version.py
+++ b/dist/shaktra/scripts/check_version.py
@@ -1,0 +1,120 @@
+#!/usr/bin/env python3
+"""Check for Shaktra plugin updates by comparing local and remote versions."""
+
+import json
+import subprocess
+import sys
+from pathlib import Path
+
+
+def read_local_version(plugin_root: str) -> tuple[str, str]:
+    """Return (version, repository_url) from local plugin.json."""
+    plugin_json = Path(plugin_root) / ".claude-plugin" / "plugin.json"
+    if not plugin_json.exists():
+        return "", ""
+    data = json.loads(plugin_json.read_text())
+    return data.get("version", ""), data.get("repository", "")
+
+
+def parse_github_owner_repo(url: str) -> tuple[str, str]:
+    """Extract owner and repo from a GitHub URL."""
+    # Handle https://github.com/owner/repo or https://github.com/owner/repo.git
+    url = url.rstrip("/").removesuffix(".git")
+    parts = url.split("/")
+    if len(parts) >= 2:
+        return parts[-2], parts[-1]
+    return "", ""
+
+
+def fetch_remote_version(owner: str, repo: str) -> str:
+    """Fetch remote plugin version from GitHub. Returns version string or empty."""
+    raw_url = (
+        f"https://raw.githubusercontent.com/{owner}/{repo}"
+        f"/main/dist/shaktra/.claude-plugin/plugin.json"
+    )
+    try:
+        result = subprocess.run(
+            ["curl", "-sf", "--max-time", "5", raw_url],
+            capture_output=True, text=True, timeout=10
+        )
+        if result.returncode == 0 and result.stdout.strip():
+            data = json.loads(result.stdout)
+            return data.get("version", "")
+    except (subprocess.TimeoutExpired, json.JSONDecodeError, OSError):
+        pass
+
+    # Fallback: gh CLI
+    try:
+        result = subprocess.run(
+            ["gh", "api",
+             f"repos/{owner}/{repo}/contents/dist/shaktra/.claude-plugin/plugin.json",
+             "--jq", ".content"],
+            capture_output=True, text=True, timeout=10
+        )
+        if result.returncode == 0 and result.stdout.strip():
+            import base64
+            decoded = base64.b64decode(result.stdout.strip()).decode()
+            data = json.loads(decoded)
+            return data.get("version", "")
+    except (subprocess.TimeoutExpired, json.JSONDecodeError, OSError):
+        pass
+
+    return ""
+
+
+def compare_semver(local: str, remote: str) -> str:
+    """Compare semver strings. Returns 'up_to_date', 'update_available', or 'ahead'."""
+    try:
+        l_parts = [int(x) for x in local.split(".")]
+        r_parts = [int(x) for x in remote.split(".")]
+        for l, r in zip(l_parts, r_parts):
+            if r > l:
+                return "update_available"
+            if l > r:
+                return "ahead"
+        return "up_to_date"
+    except (ValueError, AttributeError):
+        return "up_to_date"
+
+
+def main():
+    if len(sys.argv) < 2:
+        print("Usage: check_version.py <plugin_root>", file=sys.stderr)
+        sys.exit(1)
+
+    plugin_root = sys.argv[1]
+    local_version, repo_url = read_local_version(plugin_root)
+
+    if not local_version:
+        print(json.dumps({"error": "plugin.json not found"}))
+        sys.exit(0)
+
+    result = {
+        "local_version": local_version,
+        "repository": repo_url,
+    }
+
+    if not repo_url:
+        result["status"] = "no_repository"
+        print(json.dumps(result))
+        sys.exit(0)
+
+    owner, repo = parse_github_owner_repo(repo_url)
+    if not owner or not repo:
+        result["status"] = "invalid_repository"
+        print(json.dumps(result))
+        sys.exit(0)
+
+    remote_version = fetch_remote_version(owner, repo)
+    if not remote_version:
+        result["status"] = "offline"
+        print(json.dumps(result))
+        sys.exit(0)
+
+    result["remote_version"] = remote_version
+    result["status"] = compare_semver(local_version, remote_version)
+    print(json.dumps(result))
+
+
+if __name__ == "__main__":
+    main()

--- a/dist/shaktra/skills/shaktra-doctor/SKILL.md
+++ b/dist/shaktra/skills/shaktra-doctor/SKILL.md
@@ -30,12 +30,12 @@ FAIL: List missing files or files with invalid frontmatter.
 
 ### Check 2 — Skill Directories
 
-Glob `${CLAUDE_PLUGIN_ROOT}/skills/*/SKILL.md`. Verify all 14 skill directories exist and each SKILL.md has valid YAML frontmatter (opening and closing `---` with at least `name` and `description` fields).
+Glob `${CLAUDE_PLUGIN_ROOT}/skills/*/SKILL.md`. Verify all 15 skill directories exist and each SKILL.md has valid YAML frontmatter (opening and closing `---` with at least `name` and `description` fields).
 
 **Expected skills:**
-shaktra-analyze, shaktra-bugfix, shaktra-dev, shaktra-doctor, shaktra-general, shaktra-help, shaktra-init, shaktra-quality, shaktra-reference, shaktra-review, shaktra-stories, shaktra-tdd, shaktra-tpm, shaktra-workflow
+shaktra-analyze, shaktra-bugfix, shaktra-dev, shaktra-doctor, shaktra-general, shaktra-help, shaktra-init, shaktra-quality, shaktra-reference, shaktra-review, shaktra-status-dash, shaktra-stories, shaktra-tdd, shaktra-tpm, shaktra-workflow
 
-PASS: All 14 skill SKILL.md files exist with valid frontmatter.
+PASS: All 15 skill SKILL.md files exist with valid frontmatter.
 FAIL: List missing skills or invalid frontmatter.
 
 ### Check 3 — Hook Scripts

--- a/dist/shaktra/skills/shaktra-help/SKILL.md
+++ b/dist/shaktra/skills/shaktra-help/SKILL.md
@@ -43,6 +43,7 @@ Shaktra orchestrates 12 specialized AI agents through agile-inspired workflows. 
 | `/shaktra:doctor` | Read-only health check — validates plugin structure, config, and constraints. |
 | `/shaktra:workflow` | Natural language router — describe what you need, get dispatched to the right skill. |
 | `/shaktra:help` | This guide. |
+| `/shaktra:status-dash` | Project dashboard — version check, sprint health, quality overview. |
 
 ---
 

--- a/dist/shaktra/skills/shaktra-status-dash/SKILL.md
+++ b/dist/shaktra/skills/shaktra-status-dash/SKILL.md
@@ -1,0 +1,179 @@
+---
+name: shaktra-status-dash
+description: >
+  Full-view project dashboard. Shows plugin version and update status, sprint health,
+  story pipeline, quality summary, memory health, and analysis progress. Read-only.
+user-invocable: true
+---
+
+# /shaktra:status-dash — Project Dashboard
+
+When this skill is invoked, immediately execute all sections below in order and present the results as a formatted dashboard. Do not ask clarifying questions — just run the checks and display the output.
+
+Read-only — never create, modify, or delete any file. Use `${CLAUDE_PLUGIN_ROOT}` to locate the installed plugin directory.
+
+---
+
+## Section 1 — Plugin Info + Version Check
+
+Run the version check script via Bash:
+
+```
+python3 ${CLAUDE_PLUGIN_ROOT}/scripts/check_version.py ${CLAUDE_PLUGIN_ROOT}
+```
+
+The script outputs a JSON object. Parse the `status` field and display accordingly:
+
+| `status` value | Display |
+|---|---|
+| `up_to_date` | `Version: {local_version}` + `Up to date (v{local_version})` |
+| `update_available` | `Version: {local_version}` + `Update available: {local_version} → {remote_version}` + `Run: /plugin install {repository}` |
+| `ahead` | `Version: {local_version}` + `Local version ({local_version}) is ahead of remote ({remote_version})` |
+| `offline` | `Version: {local_version}` + `Could not check for updates (offline or rate-limited)` |
+| `no_repository` | `Version: {local_version}` + `No repository configured — version check unavailable` |
+
+If the JSON contains `"error"`, display: "Plugin not configured — plugin.json not found."
+
+---
+
+## Section 2 — Sprint Health
+
+1. Read `.shaktra/sprints.yml`.
+2. Find the sprint where `status` is `active` (or the most recent sprint).
+3. Display:
+   - Sprint ID and goal
+   - Start date → end date
+   - Days remaining (compute from end date vs today)
+   - Capacity: committed points vs capacity points
+4. If `velocity_history` exists, show the last 3 entries as a trend line (e.g., `Velocity trend: 18 → 21 → 24`).
+5. If no sprints file or no active sprint: display "No active sprint — run `/shaktra:tpm` to plan one."
+
+---
+
+## Section 3 — Story Pipeline
+
+1. Glob `.shaktra/stories/*/handoff.yml` — read each file.
+2. Extract `story_id` and `current_phase` from each handoff.
+3. Group stories by phase in pipeline order: `pending` → `plan` → `tests` → `code` → `quality` → `complete` → `failed`.
+4. Display as a table:
+
+```
+| Phase    | Count | Stories          |
+|----------|-------|------------------|
+| pending  | 2     | ST-004, ST-005   |
+| plan     | 1     | ST-003           |
+| code     | 1     | ST-002           |
+| complete | 1     | ST-001           |
+```
+
+5. Only show phases that have at least one story.
+6. If a story has `blocked: true` or `blocker` field set, append "(blocked)" after its ID.
+7. If no stories exist: display "No stories found — run `/shaktra:tpm` to create stories."
+
+---
+
+## Section 4 — Quality Summary
+
+1. Read all `.shaktra/stories/*/handoff.yml` files.
+2. For each, check for `quality_findings` (a list of findings with `severity` and `resolved` fields).
+3. Count **unresolved** findings (where `resolved` is false or absent) grouped by severity: P0, P1, P2, P3.
+4. Read `.shaktra/settings.yml` → `quality.p1_threshold` for the P1 limit.
+5. Determine merge-blocking status:
+   - **Blocked** if any unresolved P0 exists
+   - **Blocked** if unresolved P1 count exceeds `p1_threshold`
+   - **Clear** otherwise
+6. Display:
+
+```
+| Severity | Unresolved |
+|----------|------------|
+| P0       | 0          |
+| P1       | 1          |
+| P2       | 3          |
+| P3       | 2          |
+
+Merge status: Clear (P1: 1/2 threshold)
+```
+
+7. If no quality findings exist across any story: display "No quality findings recorded."
+
+---
+
+## Section 5 — Memory Health
+
+1. Read `.shaktra/memory/decisions.yml` → count top-level entries. If file is missing or empty, count is 0.
+2. Read `.shaktra/memory/lessons.yml` → count top-level entries. If file is missing or empty, count is 0.
+3. Display:
+   - `Decisions: {count}`
+   - `Lessons: {count} / 100` — 100 is the retention limit
+4. If lessons count is 90 or above, add note: "Approaching limit — oldest lessons will be rotated."
+
+---
+
+## Section 6 — Analysis Progress
+
+1. Check if `.shaktra/analysis/manifest.yml` exists. If not, skip this section entirely.
+2. Read the manifest — extract each dimension entry (D1 through D9) with its `status`.
+3. Display:
+
+```
+| Dimension | Name            | Status    |
+|-----------|-----------------|-----------|
+| D1        | Architecture    | complete  |
+| D2        | Practices       | complete  |
+| D3        | Dependencies    | pending   |
+| ...       | ...             | ...       |
+```
+
+4. Show summary: `Completed: {n}/9 dimensions`
+
+---
+
+## Graceful Degradation
+
+Each section degrades independently:
+- If a file is missing or unreadable, show a short message for that section and continue to the next.
+- **If `.shaktra/` directory does not exist**, show Section 1 (Plugin Info + Version Check) only, then display: "Project not initialized — run `/shaktra:init` to set up."
+- Never fail the entire dashboard because one section has missing data.
+
+---
+
+## Output Format
+
+Present the dashboard as a structured report:
+
+```
+## Shaktra Dashboard
+
+### Plugin Info
+Version: 0.1.0
+Status: Up to date (v0.1.0)
+
+### Sprint Health
+Sprint: S-003 — "Auth module"
+Dates: 2025-01-06 → 2025-01-20 (5 days remaining)
+Capacity: 21/30 points committed
+Velocity trend: 18 → 21 → 24
+
+### Story Pipeline
+| Phase    | Count | Stories        |
+|----------|-------|----------------|
+| code     | 1     | ST-002         |
+| complete | 2     | ST-001, ST-003 |
+
+### Quality Summary
+| Severity | Unresolved |
+|----------|------------|
+| P0       | 0          |
+| P1       | 1          |
+| P2       | 3          |
+| P3       | 2          |
+Merge status: Clear (P1: 1/2 threshold)
+
+### Memory Health
+Decisions: 4
+Lessons: 12 / 100
+
+### Analysis Progress
+Not applicable — no analysis manifest found.
+```

--- a/dist/shaktra/skills/shaktra-workflow/SKILL.md
+++ b/dist/shaktra/skills/shaktra-workflow/SKILL.md
@@ -27,6 +27,7 @@ Classify intent using a **noun-first, two-signal model**. Shaktra-specific nouns
 | Init | "initialize", "set up shaktra", "init" | init, initialize, set up | `/shaktra:init` |
 | Doctor | "health", "doctor", "diagnose", "config check", "validation" | check, diagnose, validate | `/shaktra:doctor` |
 | Help | "help", "how to use shaktra", "commands", "guide", "what can shaktra do" | help, guide, list, show | `/shaktra:help` |
+| Status Dash | "status", "dashboard", "overview", "progress", "summary" | show, check | `/shaktra:status-dash` |
 | General | No Shaktra-specific noun, domain questions (AWS, ML, docs), general technical questions | — | `/shaktra:general` |
 
 ---
@@ -38,7 +39,7 @@ When multiple routes match, resolve in this order:
 1. **Story ID + "review"** → Review (e.g., "review ST-001")
 2. **Story ID** (without "review") → Dev (e.g., "implement ST-001")
 3. **PR reference** (#number, PR URL, "pull request") → Review
-4. **Utility match** ("init", "initialize", "set up shaktra") → Init; ("doctor", "health") → Doctor; ("help", "commands", "guide") → Help
+4. **Utility match** ("init", "initialize", "set up shaktra") → Init; ("doctor", "health") → Doctor; ("help", "commands", "guide") → Help; ("status", "dashboard", "overview") → Status Dash
 5. **Noun match** → per route table; noun beats verb
 6. **Verb-only match** (no Shaktra noun) → confirm with user before routing
 7. **No match** → General
@@ -98,6 +99,7 @@ When invoked with no request text (just `/shaktra:workflow`), present available 
 | General | `/shaktra:general` | Domain expertise, architectural guidance |
 | Doctor | `/shaktra:doctor` | Health checks, config validation, diagnostics |
 | Help | `/shaktra:help` | All commands, workflows, architecture, usage guide |
+| Status Dash | `/shaktra:status-dash` | Project dashboard, version check, sprint/quality overview |
 
 You can also invoke any skill directly — the router is a convenience, not a requirement.
 

--- a/dist/shaktra/templates/CLAUDE.md
+++ b/dist/shaktra/templates/CLAUDE.md
@@ -16,6 +16,7 @@ This project uses the **Shaktra** development framework — an opinionated workf
 | `/shaktra:init` | Initialize Shaktra in a project |
 | `/shaktra:doctor` | Diagnose framework health and configuration issues |
 | `/shaktra:workflow` | Auto-route to the right agent based on intent |
+| `/shaktra:status-dash` | Project dashboard — version, sprint, stories, quality overview |
 
 ## Routing
 

--- a/scripts/test-fixture-setup.sh
+++ b/scripts/test-fixture-setup.sh
@@ -8,7 +8,7 @@ set -e
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 REPO_ROOT="$(dirname "$SCRIPT_DIR")"
-PLUGIN_DIR="${REPO_ROOT}/shaktra"
+PLUGIN_DIR="${REPO_ROOT}/dist/shaktra"
 TEST_DIR="${HOME}/workspace/project_tests/shaktra-plugin-test"
 CLAUDE_DIR="${TEST_DIR}/.claude"
 
@@ -38,6 +38,7 @@ mkdir -p "$CLAUDE_DIR"
 
 # Copy all contents from shaktra/ to .claude/
 echo "Copying from shaktra/ to .claude/..."
+cp -r "${PLUGIN_DIR}/.claude-plugin" "$CLAUDE_DIR/"
 cp -r "${PLUGIN_DIR}/agents" "$CLAUDE_DIR/"
 cp -r "${PLUGIN_DIR}/skills" "$CLAUDE_DIR/"
 cp -r "${PLUGIN_DIR}/templates" "$CLAUDE_DIR/"


### PR DESCRIPTION
Introduce /shaktra:status-dash for a read-only project overview covering plugin version (with remote update check), sprint health, story pipeline, quality summary, memory health, and analysis progress. Add check_version.py script for semver comparison against the remote repository. Update doctor, help, workflow, and CLAUDE.md template to reference the new skill. Fix test-fixture-setup.sh paths for the dist/ restructure.