### PR TITLE
Bump version to 0.1.1 and fix doctor check failures

### DIFF
--- a/dist/shaktra/.claude-plugin/plugin.json
+++ b/dist/shaktra/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "shaktra",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "description": "Opinionated software development framework with TDD, quality gates, and multi-agent orchestration",
   "repository": "https://github.com/im-shashanks/claude-plugins",
   "author": {

--- a/dist/shaktra/skills/shaktra-analyze/SKILL.md
+++ b/dist/shaktra/skills/shaktra-analyze/SKILL.md
@@ -189,6 +189,21 @@ When user requests dependency audit or upgrade planning:
 
 ---
 
+## Sub-Files
+
+| File | Purpose |
+|---|---|
+| `deep-analysis-workflow.md` | Team-based execution — 4 parallel team members with subagents |
+| `standard-analysis-workflow.md` | Single-session execution — 9 parallel CBA Analyzer agents |
+| `analysis-dimensions-core.md` | Dimension specs for D1-D4 (structure, domain, entry points, practices) |
+| `analysis-dimensions-health.md` | Dimension specs for D5-D8 (dependencies, debt, data flows, critical paths) |
+| `analysis-dimensions-git.md` | Dimension spec for D9 (git intelligence) |
+| `analysis-output-schemas.md` | YAML artifact format, summary budgets, and field definitions |
+| `debt-strategy.md` | Debt prioritization, categorization, and story generation rules |
+| `dependency-audit.md` | Dependency risk categorization and upgrade assessment rules |
+
+---
+
 ## Guard Tokens
 
 | Token | When |

--- a/dist/shaktra/skills/shaktra-pm/SKILL.md
+++ b/dist/shaktra/skills/shaktra-pm/SKILL.md
@@ -99,7 +99,7 @@ Route to the matching workflow:
 
 | Intent | Workflow File |
 |---|---|
-| `orchestrated` | `full-workflow.md` (triage → research or hypothesis path) |
+| `orchestrated` | `full-workflow.md` (triage → `full-workflow-research.md` or `full-workflow-hypothesis.md`) |
 | `prd` | `prd-workflow.md` |
 | `brainstorm` | `brainstorm-workflow.md` |
 | `personas` | `persona-workflow.md` |
@@ -124,116 +124,7 @@ After any workflow completes, present a structured summary (see Completion Repor
 
 ## Sub-Agent Prompt Templates
 
-Use these Task() prompts when spawning the PM agent in different modes.
-
-### PM — Brainstorm
-
-```
-You are the shaktra-product-manager agent operating in brainstorm mode.
-
-User's starting point: {user_context}
-Context source: {inline | document at <path>}
-Project settings: {settings summary}
-
-If context is from a document: extract and structure the existing thinking, then fill gaps.
-If context is brief: guide through problem exploration, user needs, market context.
-
-Output structured brainstorm notes to .shaktra/pm/brainstorm.md.
-```
-
-### PM — PRD Create
-
-**Before spawning, ask the user (use AskUserQuestion tool):**
-
-Question: "What size feature is this?"
-- **Standard PRD (6-8 weeks)** — Full PRD for complex features requiring design docs
-- **One-Page PRD (2-4 weeks)** — Abbreviated PRD for smaller, well-understood features
-
-Then spawn with the selected template:
-
-```
-You are the shaktra-product-manager agent operating in prd-create mode.
-
-Context:
-- Brainstorm notes: {brainstorm_path or "None"}
-- Research synthesis: {research_path or "None"}
-- Personas: {persona_paths or "None"}
-- Journey insights: {journey_summary or "None"}
-- Settings: {settings summary}
-
-Template: {standard | one-page} ← use user's selection
-
-PRD should incorporate:
-- Persona goals → success metrics
-- Journey pain points → functional requirements
-- Journey opportunities → should-have requirements
-- Moments of truth → acceptance criteria
-
-Create a PRD following the template. Write to .shaktra/prd.md.
-```
-
-### PM — PRD Review
-
-```
-You are the shaktra-product-manager agent operating in prd-review mode.
-
-PRD path: .shaktra/prd.md
-Review context: {first_review | revision_N}
-
-Check the PRD against the schema validation rules. Return QUALITY_PASS or findings.
-```
-
-### PM — Research Analyze
-
-```
-You are the shaktra-product-manager agent operating in research-analyze mode.
-
-Research inputs: {input_paths — transcripts, notes, survey data}
-Output directory: .shaktra/research/
-
-Extract pain points, feature requests, JTBD patterns. Create synthesis.yml.
-```
-
-### PM — Persona Create
-
-```
-You are the shaktra-product-manager agent operating in persona-create mode.
-
-Inputs:
-- Research synthesis: {research_path or "None"}
-- Brainstorm notes: {brainstorm_path or "None"}
-- User context: {user_context}
-
-Evidence sources (in priority order):
-1. Research interviews/surveys (if available) → high confidence
-2. Brainstorm user insights → medium confidence
-3. User's description → assumption-based
-
-Create personas with evidence links. Write to .shaktra/personas/{id}.yml.
-Minimum 2 evidence entries per persona required.
-```
-
-### PM — Journey Create
-
-```
-You are the shaktra-product-manager agent operating in journey-create mode.
-
-Persona: {persona_path}
-Research: {research_path or "Use persona evidence"}
-
-Create journey map for this persona. Write to .shaktra/journeys/{persona_id}-journey.yml.
-```
-
-### Memory Curator — Capture
-
-```
-You are the shaktra-memory-curator agent. Capture lessons from the completed workflow.
-
-Workflow type: {workflow_type}
-Artifacts path: {artifacts_path}
-
-Extract lessons that meet the capture bar. Append to .shaktra/memory/lessons.yml.
-```
+See `agent-prompts.md` for all Task() prompt templates used when spawning the PM agent and memory curator in different modes.
 
 ---
 

--- a/dist/shaktra/skills/shaktra-pm/agent-prompts.md
+++ b/dist/shaktra/skills/shaktra-pm/agent-prompts.md
@@ -1,0 +1,112 @@
+# PM Sub-Agent Prompt Templates
+
+Use these Task() prompts when spawning the PM agent in different modes.
+
+## PM — Brainstorm
+
+```
+You are the shaktra-product-manager agent operating in brainstorm mode.
+
+User's starting point: {user_context}
+Context source: {inline | document at <path>}
+Project settings: {settings summary}
+
+If context is from a document: extract and structure the existing thinking, then fill gaps.
+If context is brief: guide through problem exploration, user needs, market context.
+
+Output structured brainstorm notes to .shaktra/pm/brainstorm.md.
+```
+
+## PM — PRD Create
+
+**Before spawning, ask the user (use AskUserQuestion tool):**
+
+Question: "What size feature is this?"
+- **Standard PRD (6-8 weeks)** — Full PRD for complex features requiring design docs
+- **One-Page PRD (2-4 weeks)** — Abbreviated PRD for smaller, well-understood features
+
+Then spawn with the selected template:
+
+```
+You are the shaktra-product-manager agent operating in prd-create mode.
+
+Context:
+- Brainstorm notes: {brainstorm_path or "None"}
+- Research synthesis: {research_path or "None"}
+- Personas: {persona_paths or "None"}
+- Journey insights: {journey_summary or "None"}
+- Settings: {settings summary}
+
+Template: {standard | one-page} <- use user's selection
+
+PRD should incorporate:
+- Persona goals -> success metrics
+- Journey pain points -> functional requirements
+- Journey opportunities -> should-have requirements
+- Moments of truth -> acceptance criteria
+
+Create a PRD following the template. Write to .shaktra/prd.md.
+```
+
+## PM — PRD Review
+
+```
+You are the shaktra-product-manager agent operating in prd-review mode.
+
+PRD path: .shaktra/prd.md
+Review context: {first_review | revision_N}
+
+Check the PRD against the schema validation rules. Return QUALITY_PASS or findings.
+```
+
+## PM — Research Analyze
+
+```
+You are the shaktra-product-manager agent operating in research-analyze mode.
+
+Research inputs: {input_paths -- transcripts, notes, survey data}
+Output directory: .shaktra/research/
+
+Extract pain points, feature requests, JTBD patterns. Create synthesis.yml.
+```
+
+## PM — Persona Create
+
+```
+You are the shaktra-product-manager agent operating in persona-create mode.
+
+Inputs:
+- Research synthesis: {research_path or "None"}
+- Brainstorm notes: {brainstorm_path or "None"}
+- User context: {user_context}
+
+Evidence sources (in priority order):
+1. Research interviews/surveys (if available) -> high confidence
+2. Brainstorm user insights -> medium confidence
+3. User's description -> assumption-based
+
+Create personas with evidence links. Write to .shaktra/personas/{id}.yml.
+Minimum 2 evidence entries per persona required.
+```
+
+## PM — Journey Create
+
+```
+You are the shaktra-product-manager agent operating in journey-create mode.
+
+Persona: {persona_path}
+Research: {research_path or "Use persona evidence"}
+
+Create journey map for this persona. Write to .shaktra/journeys/{persona_id}-journey.yml.
+```
+
+## Memory Curator — Capture
+
+```
+You are the shaktra-memory-curator agent. Capture lessons from the completed workflow.
+
+Workflow type: {workflow_type}
+Artifacts path: {artifacts_path}
+
+Extract lessons that meet the capture bar. Append to .shaktra/memory/lessons.yml.
+```

--- a/dist/shaktra/skills/shaktra-reference/SKILL.md
+++ b/dist/shaktra/skills/shaktra-reference/SKILL.md
@@ -31,6 +31,10 @@ Agents load this skill via their `skills` frontmatter. Only load the sub-files y
 | `schemas/sprint-schema.md` | Sprint state — velocity tracking, backlog |
 | `schemas/design-doc-schema.md` | Design doc sections — tier-scaled structure |
 | `schemas/refactoring-handoff-schema.md` | Refactoring state machine — phases, transitions, baseline metrics |
+| `schemas/prd-schema.md` | PRD validation — required sections, quality checks |
+| `schemas/persona-schema.md` | Persona YAML — fields, evidence requirements |
+| `schemas/journey-schema.md` | Journey map YAML — stages, touchpoints, opportunities |
+| `schemas/research-schema.md` | Research synthesis YAML — themes, patterns, recommendations |
 | `schemas/analysis-manifest-schema.md` | Analysis checkpoint — dimension progress, resumability, status transitions |
 
 ## Agent Loading Guide
@@ -47,4 +51,4 @@ Agents load this skill via their `skills` frontmatter. Only load the sub-files y
 | Memory Curator | schemas/lessons-schema, schemas/handoff-schema |
 | Bug Diagnostician | severity-taxonomy, guard-tokens, schemas/story-schema |
 | CBA Analyzer | quality-principles, schemas/decisions-schema, schemas/analysis-manifest-schema |
-| Product Manager | story-tiers, schemas/story-schema, schemas/decisions-schema, schemas/sprint-schema |
+| Product Manager | story-tiers, schemas/story-schema, schemas/decisions-schema, schemas/sprint-schema, schemas/prd-schema, schemas/persona-schema, schemas/journey-schema, schemas/research-schema |


### PR DESCRIPTION
- Add status-dash version bump to 0.1.1
- Fix Check 7: Extract PM sub-agent prompt templates to agent-prompts.md (shaktra-pm/SKILL.md 315 → 206 lines)
- Fix Check 9: Add missing sub-file references in 3 SKILL.md files
  - shaktra-analyze: reference analysis-dimensions-{core,git,health}.md and analysis-output-schemas.md
  - shaktra-pm: reference full-workflow-{research,hypothesis}.md
  - shaktra-reference: reference schemas/{prd,persona,journey,research}-schema.md