### PR TITLE
fix: add marketplace README and align publish script with CI

### DIFF
--- a/.github/workflows/publish-release.yml
+++ b/.github/workflows/publish-release.yml
@@ -51,8 +51,8 @@ jobs:
               json.dumps(data, indent=2) + '\n')
           "
 
-          # Copy user-facing README from plugin directory
-          cp dist/shaktra/README.md "$BUILD/README.md"
+          # Copy marketplace README for release branch root
+          cp README-marketplace.md "$BUILD/README.md"
 
           # Copy CHANGELOG for user visibility
           cp CHANGELOG.md "$BUILD/CHANGELOG.md"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@ Format follows [Keep a Changelog](https://keepachangelog.com/). Version numbers 
 
 ## [0.1.3] - 2026-02-15
 
+### Fixed
+- **Release branch README** — Root README is now a marketplace catalog (`README-marketplace.md`) instead of a copy of Shaktra's README, fixing broken relative links to `./docs/` and `./diagrams/`
+- **Local publish script** — `scripts/publish-release.sh` rewritten to match CI workflow structure (multi-plugin `shaktra/` directory layout instead of flat root promotion)
+
 ### Added
 - **File-read tracking in test framework** — captures every Read tool invocation (including sub-agent reads) via stream-json parsing, reports which plugin reference files each workflow actually consulted
 - **Expected reads validation** — test definitions can declare `expected_reads` patterns (substring matches against file paths); dev test validates 8 patterns covering practices, quality checks, severity taxonomy, story, settings, and handoff files

--- a/README-marketplace.md
+++ b/README-marketplace.md
@@ -1,0 +1,22 @@
+# Claude Plugins
+
+Curated collection of Claude Code plugins.
+
+## Available Plugins
+
+### Shaktra
+
+Opinionated software development framework — 12 specialized AI agents,
+TDD enforcement, quality gates, sprint planning.
+
+**Install:**
+```bash
+/plugin marketplace add https://github.com/im-shashanks/claude-plugins.git
+/plugin install shaktra@cc-plugins
+```
+
+[Full documentation →](./shaktra/README.md)
+
+---
+
+*More plugins coming soon.*


### PR DESCRIPTION
Release branch root now gets a marketplace catalog README instead of Shaktra's plugin README (which had broken relative links). Local publish script rewritten to match CI's multi-plugin directory structure.