### PR TITLE
fix: add marketplace README and align publish script with CI

### DIFF
--- a/.github/workflows/publish-release.yml
+++ b/.github/workflows/publish-release.yml
@@ -7,6 +7,9 @@ on:
       - 'dist/shaktra/**'
       - '.claude-plugin/marketplace.json'
       - 'Resources/**'
+      - 'README-marketplace.md'
+      - 'CHANGELOG.md'
+  workflow_dispatch:
 
 permissions:
   contents: write


### PR DESCRIPTION
Release branch root now gets a marketplace catalog README instead of Shaktra's plugin README (which had broken relative links). Local publish script rewritten to match CI's multi-plugin directory structure.

Also adds README-marketplace.md and CHANGELOG.md to CI trigger paths, and enables workflow_dispatch for manual release runs.