### PR TITLE
fix: remove Shaktra-specific references from CLAUDE.md template

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,14 @@ Format follows [Keep a Changelog](https://keepachangelog.com/). Version numbers 
 
 ---
 
+## [0.1.5] - 2026-02-16
+
+### Changed
+- **CLAUDE.md template** — Removed all Shaktra-specific references from the project root CLAUDE.md template. Template is now a pure generic project documentation wireframe following CLAUDE.md best practices.
+- **`/shaktra:init` skill** — Updated Step 5 and Step 6 descriptions to reflect cleaned-up template (removed `/init CLAUDE.md` references and Shaktra-specific cross-links).
+
+---
+
 ## [0.1.4] - 2026-02-15
 
 ### Added

--- a/README-marketplace.md
+++ b/README-marketplace.md
@@ -43,7 +43,7 @@ Three commands take you from idea to production-ready, fully tested code:
 /plugin install https://github.com/im-shashanks/claude-plugins.git
 ```
 
-v0.1.4 | MIT License | [Full documentation](./shaktra/README.md)
+v0.1.5 | MIT License | [Full documentation](./shaktra/README.md)
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -941,7 +941,7 @@ A: Split it:
 
 See GitHub releases for changelog and version history.
 
-Current version: **0.1.4**
+Current version: **0.1.5**
 
 ---
 

--- a/dist/shaktra/.claude-plugin/plugin.json
+++ b/dist/shaktra/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "shaktra",
-  "version": "0.1.4",
+  "version": "0.1.5",
   "description": "Opinionated software development framework with TDD, quality gates, and multi-agent orchestration",
   "repository": "https://github.com/im-shashanks/claude-plugins",
   "author": {

--- a/dist/shaktra/README.md
+++ b/dist/shaktra/README.md
@@ -4,7 +4,7 @@
 
 | | |
 |---|---|
-| **Version** | 0.1.4 |
+| **Version** | 0.1.5 |
 | **License** | MIT |
 | **Claude Code** | February 2025+ |
 | **Platform** | Claude code native (macOS, Linux, Windows) |

--- a/dist/shaktra/skills/shaktra-init/SKILL.md
+++ b/dist/shaktra/skills/shaktra-init/SKILL.md
@@ -105,18 +105,16 @@ All other sections (`tdd`, `quality`, `analysis`, `sprints`) retain their templa
 
 Read the project CLAUDE.md template from `${CLAUDE_PLUGIN_ROOT}/templates/CLAUDE.md`.
 
-This template is a skeleton for documenting the **specific project** (architecture decisions, conventions, development workflow). It includes:
+This template is a generic project documentation wireframe — no Shaktra-specific content. It includes:
 - Project overview section with placeholders for name, purpose, technologies
 - Development workflow and code style guidance
 - Architecture section with component descriptions
 - Quality standards and testing requirements
 - Deployment and operations procedures
-- Decision log (referencing `.shaktra/memory/decisions.yml`)
+- Decision log
 - Contributing guidelines
 
-**Note:** A separate `.shaktra/CLAUDE.md` file is also created to document the project's development state structure (what `.shaktra/` directory contains and how Shaktra uses it). This is not about the Shaktra framework itself, but about the project's state management.
-
-The template also mentions that users can run `/init CLAUDE.md` to have Claude fill in the sections with project-specific details.
+**Note:** A separate `.shaktra/CLAUDE.md` file is also created to document the `.shaktra/` directory structure and how Shaktra agents use it.
 
 **If no CLAUDE.md exists** in the project root:
 - Create `CLAUDE.md` with the template content.
@@ -152,9 +150,9 @@ Created:
   CLAUDE.md (created | already exists)
 
 Next steps:
-  1. Update CLAUDE.md with your project-specific information (or run `/init CLAUDE.md` for Claude to do it)
+  1. Update CLAUDE.md with your project-specific information
   2. Review .shaktra/settings.yml and adjust thresholds if needed
   3. For brownfield projects: run /shaktra:analyze to understand the existing codebase
   4. Run /shaktra:tpm to create design docs and stories
-  5. For Shaktra framework reference: see plugin README.md or run /shaktra:help
+  5. Run /shaktra:help for available commands and workflows
 ```

--- a/dist/shaktra/templates/CLAUDE.md
+++ b/dist/shaktra/templates/CLAUDE.md
@@ -1,8 +1,6 @@
 # PROJECT_NAME Development
 
-**Guidance:** This file documents your specific project — architecture decisions, conventions, development workflow, and team context. For details on the `.shaktra/` directory and its contents, see `.shaktra/CLAUDE.md`.
-
-**Getting started:** Run `/init CLAUDE.md` to have Claude fill in these sections with your project details.
+**Guidance:** This file documents your specific project — architecture decisions, conventions, development workflow, and team context. Fill in each section with details relevant to your project.
 
 ---
 
@@ -131,9 +129,7 @@ _(List known issues, shortcuts, areas needing refactoring)_
 
 ## Decision Log
 
-Important architectural and design decisions are recorded in `.shaktra/memory/decisions.yml` (append-only). Key decisions:
-
-- _(Reference important decisions from decisions.yml)_
+_(Record important architectural and design decisions here, or reference where they are tracked)_
 
 ---
 
@@ -156,20 +152,3 @@ Important architectural and design decisions are recorded in `.shaktra/memory/de
    - Evidence of testing
 4. Address review feedback
 5. Merge when approved
-
-### Getting Help
-
-- **Shaktra state & directory structure:** See `.shaktra/CLAUDE.md`
-- **Shaktra commands & workflows:** Run `/shaktra:help`
-- **Project questions:** Ask team members or check decision log
-- **Technical questions:** Check this CLAUDE.md or raise an issue
-
----
-
-## Resources
-
-- **Shaktra state:** `.shaktra/CLAUDE.md` — What `.shaktra/` contains and how agents use it
-- **Decisions:** `.shaktra/memory/decisions.yml` — Architectural decisions (append-only)
-- **Lessons learned:** `.shaktra/memory/lessons.yml` — Team learnings (append-only)
-- **Sprint state:** `.shaktra/sprints.yml` — Current sprint and velocity
-- **Stories:** `.shaktra/stories/` — User story files


### PR DESCRIPTION
The project root CLAUDE.md template should be a generic project documentation wireframe — not coupled to Shaktra internals. Removed .shaktra/ cross-references, /init CLAUDE.md instructions, and the Resources section. Updated init skill descriptions to match.

Bump version to 0.1.5.